### PR TITLE
Automatic dotfile version updates

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1772408722,
-        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774870460,
-        "narHash": "sha256-DHeILNrZRmOQ8dj0MGHpjnGN+RfEoo5pHDwF+xekIl0=",
+        "lastModified": 1775104157,
+        "narHash": "sha256-rm/7k0D2J9SP30pyZ2C1HqarDncZDN6KAUI0gzgg4TA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "293490e1c1bf3bc46d7a1f2763052f0230d12e0c",
+        "rev": "41e6e2ab37763c09db4e639033392cf40900440a",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774701658,
-        "narHash": "sha256-CIS/4AMUSwUyC8X5g+5JsMRvIUL3YUfewe8K4VrbsSQ=",
+        "lastModified": 1775064974,
+        "narHash": "sha256-fp7+8MzxHrIixIIVvyORI2XpqpQnxf8NodmEHy8rczg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b63fe7f000adcfa269967eeff72c64cafecbbebe",
+        "rev": "6ebfbc38bdc6b22822a6f991f2d922306f33cfbc",
         "type": "github"
       },
       "original": {
@@ -101,11 +101,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1772328832,
-        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
+        "lastModified": 1774748309,
+        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
+        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updates the pinned input versions:
```
warning: updating lock file '/home/runner/work/dotfiles/dotfiles/flake.lock':
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/f20dc5d9b8027381c474144ecabc9034d6a839a3?narHash=sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0%3D' (2026-03-01)
  → 'github:hercules-ci/flake-parts/3107b77cd68437b9a76194f0f7f9c55f2329ca5b?narHash=sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA%3D' (2026-04-01)
• Updated input 'flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/c185c7a5e5dd8f9add5b2f8ebeff00888b070742?narHash=sha256-e%2B/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB%2BQ%3D' (2026-03-01)
  → 'github:nix-community/nixpkgs.lib/333c4e0545a6da976206c74db8773a1645b5870a?narHash=sha256-%2BU7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ%3D' (2026-03-29)
• Updated input 'home-manager':
    'github:nix-community/home-manager/293490e1c1bf3bc46d7a1f2763052f0230d12e0c?narHash=sha256-DHeILNrZRmOQ8dj0MGHpjnGN%2BRfEoo5pHDwF%2BxekIl0%3D' (2026-03-30)
  → 'github:nix-community/home-manager/41e6e2ab37763c09db4e639033392cf40900440a?narHash=sha256-rm/7k0D2J9SP30pyZ2C1HqarDncZDN6KAUI0gzgg4TA%3D' (2026-04-02)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/b63fe7f000adcfa269967eeff72c64cafecbbebe?narHash=sha256-CIS/4AMUSwUyC8X5g%2B5JsMRvIUL3YUfewe8K4VrbsSQ%3D' (2026-03-28)
  → 'github:nixos/nixpkgs/6ebfbc38bdc6b22822a6f991f2d922306f33cfbc?narHash=sha256-fp7%2B8MzxHrIixIIVvyORI2XpqpQnxf8NodmEHy8rczg%3D' (2026-04-01)
warning: Git tree '/home/runner/work/dotfiles/dotfiles' is dirty
```

This PR should automatically merge when builds have been validated.