### PR TITLE
Automatic dotfile version updates

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775104157,
-        "narHash": "sha256-rm/7k0D2J9SP30pyZ2C1HqarDncZDN6KAUI0gzgg4TA=",
+        "lastModified": 1775457580,
+        "narHash": "sha256-ikws/ssAmG20AGrEwBuwspwPlkubJu34mB+Uz2fJBJs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "41e6e2ab37763c09db4e639033392cf40900440a",
+        "rev": "5de7dbd151b0bd65d45785553d4a22d832733ffc",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775064974,
-        "narHash": "sha256-fp7+8MzxHrIixIIVvyORI2XpqpQnxf8NodmEHy8rczg=",
+        "lastModified": 1775403759,
+        "narHash": "sha256-cGyKiTspHEUx3QwAnV3RfyT+VOXhHLs+NEr17HU34Wo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6ebfbc38bdc6b22822a6f991f2d922306f33cfbc",
+        "rev": "5e11f7acce6c3469bef9df154d78534fa7ae8b6c",
         "type": "github"
       },
       "original": {
@@ -125,11 +125,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1774802402,
-        "narHash": "sha256-L1UJ/zxKTyyaGGmytH6OYlgQ0HGSMhvPkvU+iz4Mkb8=",
+        "lastModified": 1775307257,
+        "narHash": "sha256-y9hEecHH4ennFwIcw1n480YCGh73DkEmizmQnyXuvgg=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "cbd8536a05d1aae2593cb5c9ace1010c8c5845cb",
+        "rev": "2e008bb941f72379d5b935d5bfe70ed8b7c793ff",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773297127,
-        "narHash": "sha256-6E/yhXP7Oy/NbXtf1ktzmU8SdVqJQ09HC/48ebEGBpk=",
+        "lastModified": 1775125835,
+        "narHash": "sha256-2qYcPgzFhnQWchHo0SlqLHrXpux5i6ay6UHA+v2iH4U=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "71b125cd05fbfd78cab3e070b73544abe24c5016",
+        "rev": "75925962939880974e3ab417879daffcba36c4a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updates the pinned input versions:
```
warning: updating lock file '/home/runner/work/dotfiles/dotfiles/flake.lock':
• Updated input 'home-manager':
    'github:nix-community/home-manager/41e6e2ab37763c09db4e639033392cf40900440a?narHash=sha256-rm/7k0D2J9SP30pyZ2C1HqarDncZDN6KAUI0gzgg4TA%3D' (2026-04-02)
  → 'github:nix-community/home-manager/5de7dbd151b0bd65d45785553d4a22d832733ffc?narHash=sha256-ikws/ssAmG20AGrEwBuwspwPlkubJu34mB%2BUz2fJBJs%3D' (2026-04-06)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/6ebfbc38bdc6b22822a6f991f2d922306f33cfbc?narHash=sha256-fp7%2B8MzxHrIixIIVvyORI2XpqpQnxf8NodmEHy8rczg%3D' (2026-04-01)
  → 'github:nixos/nixpkgs/5e11f7acce6c3469bef9df154d78534fa7ae8b6c?narHash=sha256-cGyKiTspHEUx3QwAnV3RfyT%2BVOXhHLs%2BNEr17HU34Wo%3D' (2026-04-05)
• Updated input 'nixvim':
    'github:nix-community/nixvim/cbd8536a05d1aae2593cb5c9ace1010c8c5845cb?narHash=sha256-L1UJ/zxKTyyaGGmytH6OYlgQ0HGSMhvPkvU%2Biz4Mkb8%3D' (2026-03-29)
  → 'github:nix-community/nixvim/2e008bb941f72379d5b935d5bfe70ed8b7c793ff?narHash=sha256-y9hEecHH4ennFwIcw1n480YCGh73DkEmizmQnyXuvgg%3D' (2026-04-04)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/71b125cd05fbfd78cab3e070b73544abe24c5016?narHash=sha256-6E/yhXP7Oy/NbXtf1ktzmU8SdVqJQ09HC/48ebEGBpk%3D' (2026-03-12)
  → 'github:numtide/treefmt-nix/75925962939880974e3ab417879daffcba36c4a3?narHash=sha256-2qYcPgzFhnQWchHo0SlqLHrXpux5i6ay6UHA%2Bv2iH4U%3D' (2026-04-02)
warning: Git tree '/home/runner/work/dotfiles/dotfiles' is dirty
```

This PR should automatically merge when builds have been validated.