### PR TITLE
Automatic dotfile version updates

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775457580,
-        "narHash": "sha256-ikws/ssAmG20AGrEwBuwspwPlkubJu34mB+Uz2fJBJs=",
+        "lastModified": 1776046499,
+        "narHash": "sha256-Wzc4nn07/0RL21ypPHRzNDQZcjhIC8LaYo7QJQjM5T4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5de7dbd151b0bd65d45785553d4a22d832733ffc",
+        "rev": "287f84846c1eb3b72c986f5f6bebcff0bd67440d",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775403759,
-        "narHash": "sha256-cGyKiTspHEUx3QwAnV3RfyT+VOXhHLs+NEr17HU34Wo=",
+        "lastModified": 1775888245,
+        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5e11f7acce6c3469bef9df154d78534fa7ae8b6c",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
         "type": "github"
       },
       "original": {
@@ -125,11 +125,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1775307257,
-        "narHash": "sha256-y9hEecHH4ennFwIcw1n480YCGh73DkEmizmQnyXuvgg=",
+        "lastModified": 1776079266,
+        "narHash": "sha256-JXxmLRI18Ne4VAUzZKeVqjtMOWT6uWHk12jJQ+7UWgA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2e008bb941f72379d5b935d5bfe70ed8b7c793ff",
+        "rev": "306d2772d6647b7cde8388318042f5b95c2ce2b8",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775125835,
-        "narHash": "sha256-2qYcPgzFhnQWchHo0SlqLHrXpux5i6ay6UHA+v2iH4U=",
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "75925962939880974e3ab417879daffcba36c4a3",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updates the pinned input versions:
```
warning: updating lock file '/home/runner/work/dotfiles/dotfiles/flake.lock':
• Updated input 'home-manager':
    'github:nix-community/home-manager/5de7dbd151b0bd65d45785553d4a22d832733ffc?narHash=sha256-ikws/ssAmG20AGrEwBuwspwPlkubJu34mB%2BUz2fJBJs%3D' (2026-04-06)
  → 'github:nix-community/home-manager/287f84846c1eb3b72c986f5f6bebcff0bd67440d?narHash=sha256-Wzc4nn07/0RL21ypPHRzNDQZcjhIC8LaYo7QJQjM5T4%3D' (2026-04-13)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/5e11f7acce6c3469bef9df154d78534fa7ae8b6c?narHash=sha256-cGyKiTspHEUx3QwAnV3RfyT%2BVOXhHLs%2BNEr17HU34Wo%3D' (2026-04-05)
  → 'github:nixos/nixpkgs/13043924aaa7375ce482ebe2494338e058282925?narHash=sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90%3D' (2026-04-11)
• Updated input 'nixvim':
    'github:nix-community/nixvim/2e008bb941f72379d5b935d5bfe70ed8b7c793ff?narHash=sha256-y9hEecHH4ennFwIcw1n480YCGh73DkEmizmQnyXuvgg%3D' (2026-04-04)
  → 'github:nix-community/nixvim/306d2772d6647b7cde8388318042f5b95c2ce2b8?narHash=sha256-JXxmLRI18Ne4VAUzZKeVqjtMOWT6uWHk12jJQ%2B7UWgA%3D' (2026-04-13)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/75925962939880974e3ab417879daffcba36c4a3?narHash=sha256-2qYcPgzFhnQWchHo0SlqLHrXpux5i6ay6UHA%2Bv2iH4U%3D' (2026-04-02)
  → 'github:numtide/treefmt-nix/790751ff7fd3801feeaf96d7dc416a8d581265ba?narHash=sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0%3D' (2026-04-08)
warning: Git tree '/home/runner/work/dotfiles/dotfiles' is dirty
```

This PR should automatically merge when builds have been validated.