### PR TITLE
Automatic dotfile version updates

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776661682,
-        "narHash": "sha256-X32LTSDqUdVqMy85WYdRgyt0I75wc4Lhi9j+lrCDR8w=",
+        "lastModified": 1777498633,
+        "narHash": "sha256-+3xXjfFz7y1gNG/9tQgjdxFKsQZYcDUxz1RbzmdgXj8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4bfce11ea820df0359f73736fd59c7e8f53641a6",
+        "rev": "503480e51357c7beca8c19bde560af1491a372d0",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776329215,
-        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
+        "lastModified": 1777395829,
+        "narHash": "sha256-HposVFZcsBCevgqLR73w/BpSe8J1lMgw5kASnnxO3A4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
+        "rev": "e75f25705c2934955ee5075e62530d74aca973c6",
         "type": "github"
       },
       "original": {
@@ -125,11 +125,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1776452249,
-        "narHash": "sha256-tpCsY9kIEfcitiV3JwUqYTmxwewwZKQlZSNUBqb9kF0=",
+        "lastModified": 1777236345,
+        "narHash": "sha256-ALOqlq7bE30lsX4rA76hXeQ2aLLEpb44hS+D1+jWS88=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "698d17490e19e2e360a6ce49b1af9134d1c6eacd",
+        "rev": "a67d9cd6ff725a763afe88727aac73208ded3bf4",
         "type": "github"
       },
       "original": {

--- a/modules/work.nix
+++ b/modules/work.nix
@@ -1,7 +1,8 @@
-{ config
-, lib
-, pkgs
-, ...
+{
+  config,
+  lib,
+  pkgs,
+  ...
 }:
 
 let
@@ -16,9 +17,13 @@ in
         pkgs.kubectx
         pkgs.docker-compose
       ];
+      sessionPath = [
+        "$HOME/workspace/discord/.local/bin"
+      ];
       sessionVariables = {
         # Used by Clyde to install the updated nix version
         USE_NEW_NIX = "1";
+        LC_ALL = "en_US.UTF-8";
       };
     };
 
@@ -28,14 +33,6 @@ in
       };
 
       zsh = {
-        sessionVariables = {
-          LC_ALL = "en_US.UTF-8";
-          PATH = "$HOME/workspace/discord/.local/bin:$PATH";
-        };
-        shellAliases = {
-          work = "kitten ssh gizmo.coder -t 'cd ~/workspace/discord && zsh --login'";
-        };
-
         # We can defer to the work installation setup for fzf
         initContent = lib.mkOrder 1500 ''
           if [[ $options[zle] = on ]]; then
@@ -54,7 +51,6 @@ in
           hide-dirty = 1;
         };
       };
-
 
       nixvim = {
         # Enable some LSPs for I only care about at work

--- a/modules/zsh.nix
+++ b/modules/zsh.nix
@@ -1,6 +1,9 @@
 { ... }:
 
 {
+  home.sessionPath = [
+    "$HOME/.nix-profile/bin:$HOME/.scripts"
+  ];
   programs = {
     zsh = {
       enable = true;
@@ -40,10 +43,6 @@
         theme = "crcandy";
       };
       plugins = [ ];
-
-      sessionVariables = {
-        PATH = "$HOME/.nix-profile/bin:$HOME/.scripts:$PATH";
-      };
 
       shellAliases = {
         # Fix my typos


### PR DESCRIPTION
Updates the pinned input versions:
```
warning: updating lock file '/home/runner/work/dotfiles/dotfiles/flake.lock':
• Updated input 'home-manager':
    'github:nix-community/home-manager/4bfce11ea820df0359f73736fd59c7e8f53641a6?narHash=sha256-X32LTSDqUdVqMy85WYdRgyt0I75wc4Lhi9j%2BlrCDR8w%3D' (2026-04-20)
  → 'github:nix-community/home-manager/503480e51357c7beca8c19bde560af1491a372d0?narHash=sha256-%2B3xXjfFz7y1gNG/9tQgjdxFKsQZYcDUxz1RbzmdgXj8%3D' (2026-04-29)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/b86751bc4085f48661017fa226dee99fab6c651b?narHash=sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw%3D' (2026-04-16)
  → 'github:nixos/nixpkgs/e75f25705c2934955ee5075e62530d74aca973c6?narHash=sha256-HposVFZcsBCevgqLR73w/BpSe8J1lMgw5kASnnxO3A4%3D' (2026-04-28)
• Updated input 'nixvim':
    'github:nix-community/nixvim/698d17490e19e2e360a6ce49b1af9134d1c6eacd?narHash=sha256-tpCsY9kIEfcitiV3JwUqYTmxwewwZKQlZSNUBqb9kF0%3D' (2026-04-17)
  → 'github:nix-community/nixvim/a67d9cd6ff725a763afe88727aac73208ded3bf4?narHash=sha256-ALOqlq7bE30lsX4rA76hXeQ2aLLEpb44hS%2BD1%2BjWS88%3D' (2026-04-26)
warning: Git tree '/home/runner/work/dotfiles/dotfiles' is dirty
```

This PR should automatically merge when builds have been validated.