### PR TITLE
Improve the automated update process

### DIFF
--- a/.github/workflows/propose-updates.yml
+++ b/.github/workflows/propose-updates.yml
@@ -17,8 +17,30 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup nix
-        uses: cachix/install-nix-action@v27
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+            extra-substituters = https://attic.alpenglow.acbc.house/ci-cache
+            extra-trusted-public-keys = ci-cache:BXz8Qym/dtncWHsc5VWZY+Se/GCM3gfc1k/5IwRPV5o=
+
+      - name: Tailscale
+        uses: tailscale/github-action@v4
+        with:
+          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+          ping: alpenglow.tail771ca6.ts.net
+          statedir: /tmp/tailscale-state/
+
+      - name: Setup Attic cache
+        run: |
+          # Login to attic cache and configure nix to use it
+          nix-shell -p attic-client --command "attic login ci ${{ secrets.ATTIC_ENDPOINT }} ${{ secrets.ATTIC_TOKEN }}"
+          nix-shell -p attic-client --command "attic use ${{ secrets.ATTIC_CACHE_NAME }}"
+          # Verify the cache is configured as a substituter
+          echo "Configured substituters:"
+          nix show-config | grep substituters
 
       - name: Build pre-update closure
         id: pre-closure
@@ -40,11 +62,16 @@ jobs:
         id: closure-diff
         run: |
           NEW=$(nix build .#homeConfigurations.docker.activationPackage --no-link --print-out-paths)
+          echo "NEW=$NEW" >> "$GITHUB_OUTPUT"
           {
             echo 'CLOSURE_DIFF<<EOF'
             nix store diff-closures "${{ steps.pre-closure.outputs.OLD }}" "$NEW" 2>&1 || true
             echo EOF
           } >> "$GITHUB_OUTPUT"
+
+      - name: Push to Attic cache
+        run: |
+          nix-shell -p attic-client --command "attic push ${{ secrets.ATTIC_CACHE_NAME }} ${{ steps.closure-diff.outputs.NEW }}"
 
       - name: Print update summary (dry-run on non-main)
         if: ${{ success() && github.ref != 'refs/heads/main' }}
@@ -93,7 +120,28 @@ jobs:
           github-token: ${{ secrets.REPO_SCOPED_TOKEN }}
           discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}
           title: 'Updated dotfile version pins'
-          description: 'Automerge on [the PR with the changes](${{ steps.create-pull-request.outputs.pull-request-url }}) has been enabled.'
+          description: |
+            Automerge on [the PR with the changes](${{ steps.create-pull-request.outputs.pull-request-url }}) has been enabled.
+
+            **Package version diff:**
+            ```
+            ${{ steps.closure-diff.outputs.CLOSURE_DIFF }}
+            ```
+
+      - name: Notify about updated versions (test run)
+        if: ${{ success() && github.ref != 'refs/heads/main' }}
+        uses: nobrayner/discord-webhook@v1
+        with:
+          github-token: ${{ secrets.REPO_SCOPED_TOKEN }}
+          discord-webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          title: '[TEST] Updated dotfile version pins'
+          description: |
+            Test run on branch `${{ github.ref_name }}` — no PR was created. [View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+
+            **Package version diff:**
+            ```
+            ${{ steps.closure-diff.outputs.CLOSURE_DIFF }}
+            ```
 
       - name: Notify about failed versions update
         if: ${{ failure() && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/propose-updates.yml
+++ b/.github/workflows/propose-updates.yml
@@ -65,7 +65,8 @@ jobs:
           echo "NEW=$NEW" >> "$GITHUB_OUTPUT"
           {
             echo 'CLOSURE_DIFF<<EOF'
-            nix store diff-closures "${{ steps.pre-closure.outputs.OLD }}" "$NEW" 2>&1 || true
+            nix store diff-closures "${{ steps.pre-closure.outputs.OLD }}" "$NEW" 2>&1 \
+              | sed -E 's/\x1b\[[0-9;]*[a-zA-Z]//g' || true
             echo EOF
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/propose-updates.yml
+++ b/.github/workflows/propose-updates.yml
@@ -20,6 +20,12 @@ jobs:
       - name: Setup nix
         uses: cachix/install-nix-action@v27
 
+      - name: Build pre-update closure
+        id: pre-closure
+        run: |
+          OLD=$(nix build .#homeConfigurations.docker.activationPackage --no-link --print-out-paths)
+          echo "OLD=$OLD" >> "$GITHUB_OUTPUT"
+
       - name: Update flake versions
         id: update-versions
         run: |
@@ -28,18 +34,45 @@ jobs:
             nix flake update 2>&1
             echo EOF
           } >> "$GITHUB_OUTPUT"
+          echo "RUN_DATE=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Diff package closures
+        id: closure-diff
+        run: |
+          NEW=$(nix build .#homeConfigurations.docker.activationPackage --no-link --print-out-paths)
+          {
+            echo 'CLOSURE_DIFF<<EOF'
+            nix store diff-closures "${{ steps.pre-closure.outputs.OLD }}" "$NEW" 2>&1 || true
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Print update summary (dry-run on non-main)
+        if: ${{ success() && github.ref != 'refs/heads/main' }}
+        run: |
+          echo "Skipping PR creation because this run is not on main (ref: ${{ github.ref }})."
+          echo ""
+          echo "=== Flake input updates ==="
+          echo "${{ steps.update-versions.outputs.FLAKE_OUTPUT }}"
+          echo ""
+          echo "=== Package version diff ==="
+          echo "${{ steps.closure-diff.outputs.CLOSURE_DIFF }}"
 
       - name: Create Pull Request
-        if: ${{ success() }}
+        if: ${{ success() && github.ref == 'refs/heads/main' }}
         id: create-pull-request
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.REPO_SCOPED_TOKEN }}
-          title: Automatic dotfile version updates
+          title: "Automatic dotfile version updates (${{ steps.update-versions.outputs.RUN_DATE }})"
           body: |
             Updates the pinned input versions:
             ```
             ${{ steps.update-versions.outputs.FLAKE_OUTPUT }}
+            ```
+
+            Package version diff (against `homeConfigurations.docker`):
+            ```
+            ${{ steps.closure-diff.outputs.CLOSURE_DIFF }}
             ```
 
             This PR should automatically merge when builds have been validated.
@@ -48,7 +81,7 @@ jobs:
           base: main
 
       - name: Enable auto-merge on PR
-        if: ${{ success() && steps.create-pull-request.outputs.pull-request-number }}
+        if: ${{ success() && github.ref == 'refs/heads/main' && steps.create-pull-request.outputs.pull-request-number }}
         env:
           GH_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}
         run: gh pr merge --auto --squash ${{ steps.create-pull-request.outputs.pull-request-number }}

--- a/modules/ai.nix
+++ b/modules/ai.nix
@@ -1,17 +1,20 @@
-{ config
-, lib
-, pkgs
-, ...
+{
+  config,
+  lib,
+  pkgs,
+  ...
 }:
 
 let
-  inherit (lib) mkIf;
+  inherit (lib) mkIf optionals;
   inherit (config.gizmo) ai;
 in
 {
   config = {
     home = {
-      packages = mkIf ai.tools [
+      packages = [
+        pkgs.pi-coding-agent
+      ] ++ optionals ai.tools [
         pkgs.claude-code
         pkgs.claude-agent-acp
       ];
@@ -42,4 +45,3 @@ in
     };
   };
 }
-


### PR DESCRIPTION
# What's changing?

This makes a couple improvements to the weekly automated update flow. Namely:
- Adds a date to the PR title
- Generates a package version diff between the old and new versions. This version diff is included in the PR body and the Discord webhook notification
- Makes this workflow behave like a dry-run when triggered on a non-main branch.

# Why is it changing?

Going back over time, it'd be nice to get a sense for when these PRs happened without having to dig into the dates on the commits. Additionally, getting a better summary of what's actually changing beyond just the diff on the flake would be handy.