### PR TITLE
Automatic dotfile version updates (2026-05-04)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "lastModified": 1777898446,
+        "narHash": "sha256-tTEOTTjMHd8Vffn4hehLTPgOXXxJ27xfkf4DoyZgD7s=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "rev": "5d82aa3d6b5da25dbfec1a995750a70a03b8c659",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777498633,
-        "narHash": "sha256-+3xXjfFz7y1gNG/9tQgjdxFKsQZYcDUxz1RbzmdgXj8=",
+        "lastModified": 1777913624,
+        "narHash": "sha256-4MwfrGuqjsnEORQbM3cmkmG/9cWhDV63dTDguDj4FXw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "503480e51357c7beca8c19bde560af1491a372d0",
+        "rev": "a89686d115e970e200eb2caa7603f3673050e00c",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777395829,
-        "narHash": "sha256-HposVFZcsBCevgqLR73w/BpSe8J1lMgw5kASnnxO3A4=",
+        "lastModified": 1777826146,
+        "narHash": "sha256-wQ/iN5Zp5VIa3ebBibijPnLyKhor+xEbDy4d0goa9Zs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e75f25705c2934955ee5075e62530d74aca973c6",
+        "rev": "73c703c22422b8951895a960959dbbaca7296492",
         "type": "github"
       },
       "original": {
@@ -101,11 +101,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1774748309,
-        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
         "type": "github"
       },
       "original": {
@@ -125,11 +125,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1777236345,
-        "narHash": "sha256-ALOqlq7bE30lsX4rA76hXeQ2aLLEpb44hS+D1+jWS88=",
+        "lastModified": 1777895210,
+        "narHash": "sha256-HyOrBrEZYLEDV7M+t9NJhlsLFITILs3hWGEQFrppIjo=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "a67d9cd6ff725a763afe88727aac73208ded3bf4",
+        "rev": "b0d7187d1d49239a5ce18d2bbf5dea5a954849a9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updates the pinned input versions:
```
unpacking 'github:hercules-ci/flake-parts/5d82aa3d6b5da25dbfec1a995750a70a03b8c659' into the Git cache...
unpacking 'github:nix-community/home-manager/a89686d115e970e200eb2caa7603f3673050e00c' into the Git cache...
unpacking 'github:nixos/nixpkgs/73c703c22422b8951895a960959dbbaca7296492' into the Git cache...
unpacking 'github:nix-community/nixvim/b0d7187d1d49239a5ce18d2bbf5dea5a954849a9' into the Git cache...
unpacking 'github:NuschtOS/search/d15c05d20b434704c3e84f9dea161b8184b6643d' into the Git cache...
unpacking 'github:numtide/treefmt-nix/790751ff7fd3801feeaf96d7dc416a8d581265ba' into the Git cache...
warning: updating lock file "/home/runner/work/dotfiles/dotfiles/flake.lock":
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/3107b77' (2026-04-01)
  → 'github:hercules-ci/flake-parts/5d82aa3' (2026-05-04)
• Updated input 'flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/333c4e0' (2026-03-29)
  → 'github:nix-community/nixpkgs.lib/f590132' (2026-04-26)
• Updated input 'home-manager':
    'github:nix-community/home-manager/503480e' (2026-04-29)
  → 'github:nix-community/home-manager/a89686d' (2026-05-04)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/e75f257' (2026-04-28)
  → 'github:nixos/nixpkgs/73c703c' (2026-05-03)
• Updated input 'nixvim':
    'github:nix-community/nixvim/a67d9cd' (2026-04-26)
  → 'github:nix-community/nixvim/b0d7187' (2026-05-04)
```

Package version diff (against `homeConfigurations.docker`):
```
btop: 1.4.6 → 1.4.7, 61.3 KiB
claude-code: 2.1.119 → 2.1.123, 2.4 MiB
gh: 2.91.0 → 2.92.0, 28.7 KiB
home-configuration-reference: 51.0 KiB
libblake3: 1.8.4 → 1.8.5
source: 93.3 KiB
```

This PR should automatically merge when builds have been validated.