### PR TITLE
Automatic dotfile version updates (2026-05-11)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1777898446,
-        "narHash": "sha256-tTEOTTjMHd8Vffn4hehLTPgOXXxJ27xfkf4DoyZgD7s=",
+        "lastModified": 1777988971,
+        "narHash": "sha256-qIoWPDs+0/8JecyYgE3gpKQxW/4bLW/gp45vow9ioCQ=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "5d82aa3d6b5da25dbfec1a995750a70a03b8c659",
+        "rev": "0678d8986be1661af6bb555f3489f2fdfc31f6ff",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777913624,
-        "narHash": "sha256-4MwfrGuqjsnEORQbM3cmkmG/9cWhDV63dTDguDj4FXw=",
+        "lastModified": 1778503501,
+        "narHash": "sha256-08L/X4/do7nET4rzidJ76eV/1r+mB7DchVpdPypsghc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a89686d115e970e200eb2caa7603f3673050e00c",
+        "rev": "85ba629c79449badf4338117c27f0ee92b4b9f1a",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777826146,
-        "narHash": "sha256-wQ/iN5Zp5VIa3ebBibijPnLyKhor+xEbDy4d0goa9Zs=",
+        "lastModified": 1778458615,
+        "narHash": "sha256-cY07EsdhBJ8tFXPzDYevgqxRev9ZLxFonuq9wmq5kwg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "73c703c22422b8951895a960959dbbaca7296492",
+        "rev": "c6e5ca3c836a5f4dd9af9f2c1fc1c38f0fac988a",
         "type": "github"
       },
       "original": {
@@ -125,11 +125,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1777895210,
-        "narHash": "sha256-HyOrBrEZYLEDV7M+t9NJhlsLFITILs3hWGEQFrppIjo=",
+        "lastModified": 1777991353,
+        "narHash": "sha256-DFwjggMV+nzCZpwK6Obxj9F+P59rbLVowGqHETfctBk=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "b0d7187d1d49239a5ce18d2bbf5dea5a954849a9",
+        "rev": "7986a276960b4dfaed9bb2c3c438b5ba71ae08f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updates the pinned input versions:
```
unpacking 'github:hercules-ci/flake-parts/0678d8986be1661af6bb555f3489f2fdfc31f6ff' into the Git cache...
unpacking 'github:nix-community/home-manager/85ba629c79449badf4338117c27f0ee92b4b9f1a' into the Git cache...
unpacking 'github:nixos/nixpkgs/c6e5ca3c836a5f4dd9af9f2c1fc1c38f0fac988a' into the Git cache...
unpacking 'github:nix-community/nixvim/7986a276960b4dfaed9bb2c3c438b5ba71ae08f1' into the Git cache...
unpacking 'github:NuschtOS/search/d15c05d20b434704c3e84f9dea161b8184b6643d' into the Git cache...
unpacking 'github:numtide/treefmt-nix/790751ff7fd3801feeaf96d7dc416a8d581265ba' into the Git cache...
warning: updating lock file "/home/runner/work/dotfiles/dotfiles/flake.lock":
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/5d82aa3' (2026-05-04)
  → 'github:hercules-ci/flake-parts/0678d89' (2026-05-05)
• Updated input 'home-manager':
    'github:nix-community/home-manager/a89686d' (2026-05-04)
  → 'github:nix-community/home-manager/85ba629' (2026-05-11)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/73c703c' (2026-05-03)
  → 'github:nixos/nixpkgs/c6e5ca3' (2026-05-11)
• Updated input 'nixvim':
    'github:nix-community/nixvim/b0d7187' (2026-05-04)
  → 'github:nix-community/nixvim/7986a27' (2026-05-05)
```

Package version diff (against `homeConfigurations.docker`):
```
claude-agent-acp: 0.21.0 → 0.32.0, 408.5 MiB
claude-code: 2.1.123 → 2.1.137, -16.4 MiB
nix: 2.34.6 → 2.34.7, 9.1 KiB
nix-cmd: 2.34.6 → 2.34.7
nix-expr: 2.34.6 → 2.34.7
nix-fetchers: 2.34.6 → 2.34.7
nix-flake: 2.34.6 → 2.34.7
nix-main: 2.34.6 → 2.34.7
nix-nswrapper: 2.34.6 → 2.34.7
nix-store: 2.34.6 → 2.34.7
nix-util: 2.34.6 → 2.34.7
pi-coding-agent: 0.70.5 → 0.73.0, -93.0 MiB
pyrefly: 0.62.0 → 0.63.1, 208.6 KiB
sd-switch: 0.6.2 → 0.6.3, 15.1 KiB
uv: 0.11.8 → 0.11.11, 76.8 KiB
vimplugin-luajit2.1-lualine.nvim-scm: 3-unstable-scm-3 → 4-unstable-scm-4
vimplugin-nvim-tree.lua: 1.17.0-unstable-2026-04-25 → 1.17.0-unstable-2026-04-30
```

This PR should automatically merge when builds have been validated.