### PR TITLE
Automatic dotfile version updates (2026-05-18)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1777988971,
-        "narHash": "sha256-qIoWPDs+0/8JecyYgE3gpKQxW/4bLW/gp45vow9ioCQ=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "0678d8986be1661af6bb555f3489f2fdfc31f6ff",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -66,11 +66,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778503501,
-        "narHash": "sha256-08L/X4/do7nET4rzidJ76eV/1r+mB7DchVpdPypsghc=",
+        "lastModified": 1779103424,
+        "narHash": "sha256-hBYJz5jnRDjACPrwdD064zwMW+s5bdNlG/lNQipLhgM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "85ba629c79449badf4338117c27f0ee92b4b9f1a",
+        "rev": "dd71501fb7005264feb4de78444a2e1518cd4f66",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778458615,
-        "narHash": "sha256-cY07EsdhBJ8tFXPzDYevgqxRev9ZLxFonuq9wmq5kwg=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c6e5ca3c836a5f4dd9af9f2c1fc1c38f0fac988a",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {
@@ -148,11 +148,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1777991353,
-        "narHash": "sha256-DFwjggMV+nzCZpwK6Obxj9F+P59rbLVowGqHETfctBk=",
+        "lastModified": 1779092748,
+        "narHash": "sha256-NliK7JRrPh44IbVwoLi/s7dleSfwoGXgu69d1PjhYdw=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7986a276960b4dfaed9bb2c3c438b5ba71ae08f1",
+        "rev": "2e60ad952a9f4b0a1c275a79a1a44c8e3a088789",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updates the pinned input versions:
```
unpacking 'github:hercules-ci/flake-parts/f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb' into the Git cache...
unpacking 'github:nix-community/home-manager/dd71501fb7005264feb4de78444a2e1518cd4f66' into the Git cache...
unpacking 'github:nixos/nixpkgs/d233902339c02a9c334e7e593de68855ad26c4cb' into the Git cache...
unpacking 'github:nix-community/nixvim/2e60ad952a9f4b0a1c275a79a1a44c8e3a088789' into the Git cache...
unpacking 'github:NuschtOS/search/d15c05d20b434704c3e84f9dea161b8184b6643d' into the Git cache...
unpacking 'github:numtide/treefmt-nix/790751ff7fd3801feeaf96d7dc416a8d581265ba' into the Git cache...
warning: updating lock file "/home/runner/work/dotfiles/dotfiles/flake.lock":
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/0678d89' (2026-05-05)
  → 'github:hercules-ci/flake-parts/f7c1a2d' (2026-05-13)
• Updated input 'home-manager':
    'github:nix-community/home-manager/85ba629' (2026-05-11)
  → 'github:nix-community/home-manager/dd71501' (2026-05-18)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/c6e5ca3' (2026-05-11)
  → 'github:nixos/nixpkgs/d233902' (2026-05-15)
• Updated input 'nixvim':
    'github:nix-community/nixvim/7986a27' (2026-05-05)
  → 'github:nix-community/nixvim/2e60ad9' (2026-05-18)
```

Package version diff (against `homeConfigurations.docker`):
```
alsa-lib: 1.2.15.3 added, 1.8 MiB
alsa-topology-conf: 1.2.5.1 added, 336.1 KiB
alsa-ucm-conf: 1.2.15.3 added, 841.8 KiB
claude-agent-acp: 0.32.0 → 0.33.1, 3.4 MiB
claude-code: 2.1.137 → 2.1.141, 1.9 MiB
home-configuration-reference: 15.4 KiB
libgit2: 1.9.2 → 1.9.3
ruff: 0.15.12 → 0.15.13, 82.8 KiB
source: -2.0 MiB
uv: 0.11.11 → 0.11.14, 93.3 KiB
vimplugin-nvim-lspconfig: 2.8.0 → 2.9.0, 229.3 KiB
vimplugin-telescope-fzf-native.nvim: 0-unstable-2025-11-07 → 0-unstable-2026-05-06
vimplugin-vim-floaterm: 0-unstable-2026-02-10 → 0-unstable-2026-05-07
```

This PR should automatically merge when builds have been validated.