### PR TITLE
Automatic dotfile version updates (2026-05-25)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -66,11 +66,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779103424,
-        "narHash": "sha256-hBYJz5jnRDjACPrwdD064zwMW+s5bdNlG/lNQipLhgM=",
+        "lastModified": 1779678629,
+        "narHash": "sha256-gHcIFg0mm+KFsg7iZQt67kni3+qR5U3PhEC9P7vKlZ4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "dd71501fb7005264feb4de78444a2e1518cd4f66",
+        "rev": "612bbe3b405ad5f71d7bf9edecc04b678a061652",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1779536132,
+        "narHash": "sha256-q+fF42iv/geEbHfgSzy3tS0FF/EyD6XTZ98E6yxiBO8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456",
         "type": "github"
       },
       "original": {
@@ -148,11 +148,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1779092748,
-        "narHash": "sha256-NliK7JRrPh44IbVwoLi/s7dleSfwoGXgu69d1PjhYdw=",
+        "lastModified": 1779683452,
+        "narHash": "sha256-Ksx8jghpDBCPDiTaTyGhYUXG1BUwqPjf5pajl0q0cqA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2e60ad952a9f4b0a1c275a79a1a44c8e3a088789",
+        "rev": "afec1bae0e6f7983a5c03ec559f7ed2ec0e714a9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updates the pinned input versions:
```
unpacking 'github:nix-community/home-manager/612bbe3b405ad5f71d7bf9edecc04b678a061652' into the Git cache...
unpacking 'github:nixos/nixpkgs/3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456' into the Git cache...
unpacking 'github:nix-community/nixvim/afec1bae0e6f7983a5c03ec559f7ed2ec0e714a9' into the Git cache...
unpacking 'github:NuschtOS/search/d15c05d20b434704c3e84f9dea161b8184b6643d' into the Git cache...
unpacking 'github:numtide/treefmt-nix/790751ff7fd3801feeaf96d7dc416a8d581265ba' into the Git cache...
warning: updating lock file "/home/runner/work/dotfiles/dotfiles/flake.lock":
• Updated input 'home-manager':
    'github:nix-community/home-manager/dd71501' (2026-05-18)
  → 'github:nix-community/home-manager/612bbe3' (2026-05-25)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/d233902' (2026-05-15)
  → 'github:nixos/nixpkgs/3d8f0f3' (2026-05-23)
• Updated input 'nixvim':
    'github:nix-community/nixvim/2e60ad9' (2026-05-18)
  → 'github:nix-community/nixvim/afec1ba' (2026-05-25)
```

Package version diff (against `homeConfigurations.docker`):
```
agent-mux: 28.4 KiB
asciinema: 27.4 KiB
aws-c-event-stream: 0.5.7 → 0.7.0
bat: 22.1 KiB
bubblewrap: 0.11.1 → 0.11.2
claude-agent-acp: 0.33.1 → 0.36.1, -29.3 MiB
claude-code: 2.1.141 → 2.1.148, 4.3 MiB
coreutils: 9.10 → 9.11, 88.7 KiB
curl: 8.19.0 → 8.20.0
delta: 34.7 KiB
expat: 2.7.5 → 2.8.0
eza: 16.9 KiB
fd: 24.9 KiB
file: 5.45 → 5.47, 2.0 MiB
gdk-pixbuf: 2.44.5 → 2.44.6
gh: 40.0 KiB
git: 2.53.0 → 2.54.0, 933.4 KiB
glib: 2.86.3 → 2.88.1, 279.7 KiB
gnupg: -1.2 MiB
gnutar: 1.35 removed, -2.7 MiB
gnutls: 3.8.12 → 3.8.13, 209.4 KiB
home-configuration-reference: -10.6 KiB
jemalloc: 5.3.0-unstable-2025-09-12 → 5.3.1, -2.6 MiB
lazydocker: 12.0 KiB
lazygit: 16.3 KiB
libarchive: 3.8.6 → 3.8.7
libbpf: 1.6.3 → 1.7.0, 72.8 KiB
libcap-ng: 0.9.2 → 0.9.3
libfido2: 1.16.0 → 1.17.0, 47.9 KiB
libidn2: -8.8 KiB
libsodium: 1.0.21-unstable-2026-03-29 → 1.0.22-unstable-2026-04-09, 42.6 KiB
libxml2: 2.15.1 → 2.15.2
llhttp: 9.3.1 → 9.4.1
luajit: 2.1.1741730670 → 2.1.1774638290, 12.8 KiB
lvm2: 2.03.38 → 2.03.39, 25.7 KiB
nghttp2: 1.68.1 → 1.69.0, -115.5 KiB
ngtcp2: 1.22.0 → 1.22.1
nil: 20.9 KiB
nodejs: 24.14.1 → 24.15.0, -11.4 KiB
nodejs-slim: 24.14.1 → 24.15.0, 2.3 MiB
nvim-host-python3: 3.13.12 → 3.13.13
openssl: 3.6.1 → 3.6.2
perl5.42.0-Mozilla-CA: -56.0 KiB
pi-coding-agent: 0.73.0 → 0.75.4, -127.3 MiB
pyrefly: 0.63.1 → 1.0.0, 464.5 KiB
python3: 3.13.12 → 3.13.13, 134.9 KiB
ripgrep: -137.2 KiB
ruby: 55.2 KiB
ruff: 99.9 KiB
sd-switch: 28.4 KiB
simdutf: 8.1.0 → 9.0.0, 659.3 KiB
source: 42.2 KiB
systemd: 37.0 KiB
tree-sitter: 11.2 KiB
tzdata: 2026a → 2026b
unbound: 1.24.2 → 1.25.0, 12.8 KiB
util-linux-minimal: -139.9 KiB
uv: 0.11.14 → 0.11.15, -837.9 KiB
vimplugin-markview.nvim: 28.2.0 → 28.3.0
vimplugin-nvim-tree.lua: 1.17.0-unstable-2026-04-30 → 1.17.0-unstable-2026-05-15
wayland: 1.24.0 → 1.25.0
xdg-user-dirs: 0.19 → 0.20, 15.8 KiB
```

This PR should automatically merge when builds have been validated.