### PR TITLE
Automatic dotfile version updates (2026-06-01)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779868335,
-        "narHash": "sha256-fngvnldiUiKh3h6zut7P2PjKSpdG3+8cFg+wJrrMGAI=",
+        "lastModified": 1780096207,
+        "narHash": "sha256-HB7smnNETe973o0Ok6Dq8jaFYr45bR2Vbnh2JTgysyY=",
         "owner": "gizmo385",
         "repo": "mux",
-        "rev": "9364a8d28d3d72d5eadbefa328065c3d5c5cd0b5",
+        "rev": "4b8660aabdfb2462fd8c1d1d3d01eef6196ab6dd",
         "type": "github"
       },
       "original": {
@@ -66,11 +66,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779678629,
-        "narHash": "sha256-gHcIFg0mm+KFsg7iZQt67kni3+qR5U3PhEC9P7vKlZ4=",
+        "lastModified": 1780099287,
+        "narHash": "sha256-efIPwVGtIWIjWcznhaop6XN6HxnOL8800hF6CBNvlqQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "612bbe3b405ad5f71d7bf9edecc04b678a061652",
+        "rev": "7d8127d308c3fb9664f7e643eec944be74ebb37d",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779536132,
-        "narHash": "sha256-q+fF42iv/geEbHfgSzy3tS0FF/EyD6XTZ98E6yxiBO8=",
+        "lastModified": 1780030872,
+        "narHash": "sha256-u6WU/yd/o8iYQrHX3RAwO1hYa3LkoSL+WNQD0rJfJZQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456",
+        "rev": "e9a7635a57597d9754eccebdfc7045e6c8600e6b",
         "type": "github"
       },
       "original": {
@@ -148,11 +148,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1779683452,
-        "narHash": "sha256-Ksx8jghpDBCPDiTaTyGhYUXG1BUwqPjf5pajl0q0cqA=",
+        "lastModified": 1780235872,
+        "narHash": "sha256-/TTVFhJQ5StCOrRFO+5NfSkYPSbAAekwymovcQzxNgE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "afec1bae0e6f7983a5c03ec559f7ed2ec0e714a9",
+        "rev": "e5c7b40dc569f5c97ba2182d409f0fb54c02d7c1",
         "type": "github"
       },
       "original": {
@@ -172,11 +172,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776097945,
-        "narHash": "sha256-zQFcpo9Caj9ZLvjGHnvXsPjwyUmznf1kixcMA0+e0bw=",
+        "lastModified": 1779818959,
+        "narHash": "sha256-bdYUEL9fboBFaKnqO4Vhh84XF5qriXwBiT/hNOIf/fA=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "d15c05d20b434704c3e84f9dea161b8184b6643d",
+        "rev": "7470004b7cb9459f1427692d7ee4e36888dbc022",
         "type": "github"
       },
       "original": {
@@ -214,15 +214,16 @@
     },
     "systems_2": {
       "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "lastModified": 1774449309,
+        "narHash": "sha256-brhZ8DmuGtzkCYHJg4HEd602amKm89Y9ytsFZ5uWD1w=",
         "owner": "nix-systems",
         "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "rev": "c29398b59d2048c4ab79345812849c9bd15e9150",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
+        "ref": "future-26.11",
         "repo": "default",
         "type": "github"
       }
@@ -234,11 +235,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775636079,
-        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updates the pinned input versions:
```
unpacking 'github:gizmo385/mux/4b8660aabdfb2462fd8c1d1d3d01eef6196ab6dd' into the Git cache...
unpacking 'github:nix-community/home-manager/7d8127d308c3fb9664f7e643eec944be74ebb37d' into the Git cache...
unpacking 'github:nixos/nixpkgs/e9a7635a57597d9754eccebdfc7045e6c8600e6b' into the Git cache...
unpacking 'github:nix-community/nixvim/e5c7b40dc569f5c97ba2182d409f0fb54c02d7c1' into the Git cache...
unpacking 'github:NuschtOS/search/7470004b7cb9459f1427692d7ee4e36888dbc022' into the Git cache...
unpacking 'github:numtide/treefmt-nix/db947814a175b7ca6ded66e21383d938df01c227' into the Git cache...
warning: updating lock file "/home/runner/work/dotfiles/dotfiles/flake.lock":
• Updated input 'agent-mux':
    'github:gizmo385/mux/9364a8d' (2026-05-27)
  → 'github:gizmo385/mux/4b8660a' (2026-05-29)
• Updated input 'home-manager':
    'github:nix-community/home-manager/612bbe3' (2026-05-25)
  → 'github:nix-community/home-manager/7d8127d' (2026-05-30)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/3d8f0f3' (2026-05-23)
  → 'github:nixos/nixpkgs/e9a7635' (2026-05-29)
• Updated input 'nixvim':
    'github:nix-community/nixvim/afec1ba' (2026-05-25)
  → 'github:nix-community/nixvim/e5c7b40' (2026-05-31)
• Updated input 'nixvim/systems':
    'github:nix-systems/default/da67096' (2023-04-09)
  → 'github:nix-systems/default/c29398b' (2026-03-25)
• Updated input 'nuschtosSearch':
    'github:NuschtOS/search/d15c05d' (2026-04-13)
  → 'github:NuschtOS/search/7470004' (2026-05-26)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/790751f' (2026-04-08)
  → 'github:numtide/treefmt-nix/db94781' (2026-05-31)
```

Package version diff (against `homeConfigurations.docker`):
```
claude-code: 2.1.148 → 2.1.154, 3.2 MiB
fzf: 0.72.0 → 0.73.1, 71.9 KiB
gh: 2.92.0 → 2.93.0, 52.1 KiB
lazygit: 0.61.1 → 0.62.1, 834.8 KiB
ruff: 0.15.13 → 0.15.14, 42.5 KiB
uv: 0.11.15 → 0.11.16, 599.4 KiB
```

This PR should automatically merge when builds have been validated.