### PR TITLE
Automatic dotfile version updates (2026-06-08)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -66,11 +66,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780099287,
-        "narHash": "sha256-efIPwVGtIWIjWcznhaop6XN6HxnOL8800hF6CBNvlqQ=",
+        "lastModified": 1780885330,
+        "narHash": "sha256-aMA5oAq2Iv467U9s8YOb50DYQT9w0WJbyWqwlzHuLMs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7d8127d308c3fb9664f7e643eec944be74ebb37d",
+        "rev": "4fe95527cbe952713318ada8a4d122e1a6ab120f",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780030872,
-        "narHash": "sha256-u6WU/yd/o8iYQrHX3RAwO1hYa3LkoSL+WNQD0rJfJZQ=",
+        "lastModified": 1780747962,
+        "narHash": "sha256-IX7G1dlKrOqPOImfbo7ADDfV5yU1+j+MRChI3TL4tAA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e9a7635a57597d9754eccebdfc7045e6c8600e6b",
+        "rev": "cbb5cf358f50aa6acc9efd6113b7bcfbc352cd73",
         "type": "github"
       },
       "original": {
@@ -148,11 +148,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1780235872,
-        "narHash": "sha256-/TTVFhJQ5StCOrRFO+5NfSkYPSbAAekwymovcQzxNgE=",
+        "lastModified": 1780884186,
+        "narHash": "sha256-ueTLp7DofvIZ0BXEWwi8AjP1cCsuEfO445dk6DtmfKc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "e5c7b40dc569f5c97ba2182d409f0fb54c02d7c1",
+        "rev": "82f2ec369eb597554a71ec82f33922d01b7dba8f",
         "type": "github"
       },
       "original": {
@@ -172,11 +172,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779818959,
-        "narHash": "sha256-bdYUEL9fboBFaKnqO4Vhh84XF5qriXwBiT/hNOIf/fA=",
+        "lastModified": 1780920922,
+        "narHash": "sha256-tf3fIqMVHiy/NqmOjPIWdbd34/QehVaIG4f2dihkQ2Y=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "7470004b7cb9459f1427692d7ee4e36888dbc022",
+        "rev": "497eedec7bf40e7a91cd7bd837df80f6947b39fc",
         "type": "github"
       },
       "original": {

--- a/modules/ai.nix
+++ b/modules/ai.nix
@@ -1,9 +1,8 @@
-{
-  config,
-  inputs,
-  lib,
-  pkgs,
-  ...
+{ config
+, inputs
+, lib
+, pkgs
+, ...
 }:
 
 let
@@ -37,10 +36,12 @@ let
   );
   # basename-without-extension -> filename, e.g. "airplane-chime" -> "airplane-chime.mp3"
   soundsByName = lib.listToAttrs (
-    map (f: {
-      name = lib.removeSuffix ".wav" (lib.removeSuffix ".mp3" f);
-      value = f;
-    }) soundFiles
+    map
+      (f: {
+        name = lib.removeSuffix ".wav" (lib.removeSuffix ".mp3" f);
+        value = f;
+      })
+      soundFiles
   );
   selectedChimeFile = soundsByName.${ai.muxChime};
   agentMuxChimePath = "${config.xdg.dataHome}/sounds/${selectedChimeFile}";
@@ -54,26 +55,26 @@ let
   };
 
   soundHomeFiles = lib.listToAttrs (
-    map (f: {
-      name = "agent_mux_sound_${lib.replaceStrings [ "-" "." ] [ "_" "_" ] f}";
-      value = {
-        source = soundsSrc + "/${f}";
-        target = ".local/share/sounds/${f}";
-      };
-    }) soundFiles
+    map
+      (f: {
+        name = "agent_mux_sound_${lib.replaceStrings [ "-" "." ] [ "_" "_" ] f}";
+        value = {
+          source = soundsSrc + "/${f}";
+          target = ".local/share/sounds/${f}";
+        };
+      })
+      soundFiles
   );
 in
 {
   config = {
     home = {
-      packages = [
-        pkgs.pi-coding-agent
-      ]
-      ++ optionals ai.tools [
+      packages = [ ]
+        ++ optionals ai.tools [
         pkgs.claude-code
         pkgs.claude-agent-acp
       ]
-      ++ optionals ai.mux [
+        ++ optionals ai.mux [
         agent-mux
       ];
 


### PR DESCRIPTION
Updates the pinned input versions:
```
unpacking 'github:nix-community/home-manager/4fe95527cbe952713318ada8a4d122e1a6ab120f' into the Git cache...
unpacking 'github:nixos/nixpkgs/cbb5cf358f50aa6acc9efd6113b7bcfbc352cd73' into the Git cache...
unpacking 'github:nix-community/nixvim/82f2ec369eb597554a71ec82f33922d01b7dba8f' into the Git cache...
unpacking 'github:NuschtOS/search/497eedec7bf40e7a91cd7bd837df80f6947b39fc' into the Git cache...
unpacking 'github:numtide/treefmt-nix/db947814a175b7ca6ded66e21383d938df01c227' into the Git cache...
warning: updating lock file "/home/runner/work/dotfiles/dotfiles/flake.lock":
• Updated input 'home-manager':
    'github:nix-community/home-manager/7d8127d' (2026-05-30)
  → 'github:nix-community/home-manager/4fe9552' (2026-06-08)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/e9a7635' (2026-05-29)
  → 'github:nixos/nixpkgs/cbb5cf3' (2026-06-06)
• Updated input 'nixvim':
    'github:nix-community/nixvim/e5c7b40' (2026-05-31)
  → 'github:nix-community/nixvim/82f2ec3' (2026-06-08)
• Updated input 'nuschtosSearch':
    'github:NuschtOS/search/7470004' (2026-05-26)
  → 'github:NuschtOS/search/497eede' (2026-06-08)
```

Package version diff (against `homeConfigurations.docker`):
```
claude-agent-acp: 0.36.1 → 0.39.0, -209.0 MiB
claude-code: 2.1.154 → 2.1.161, 2.9 MiB
hm_..zprofile: (no version) added
home-configuration-reference: 16.5 KiB
lazygit: 0.62.1 → 0.62.2
libgit2: 1.9.3 → 1.9.4
nixfmt: 1.2.0 → 1.3.1, 83.8 KiB
pi-coding-agent: 0.75.4 → 0.78.0, -23.8 MiB
ruff: 0.15.14 → 0.15.15, -239.9 KiB
source: 109.8 KiB
uv: 0.11.16 → 0.11.17, 431.9 KiB
vimplugin-luajit2.1-lualine.nvim-scm: 4-unstable-scm-4 → 5-unstable-scm-5
zsh: 5.9 → 5.9.1, 307.9 KiB
```

This PR should automatically merge when builds have been validated.