### PR TITLE
Automatic dotfile version updates (2026-06-22)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780096207,
-        "narHash": "sha256-HB7smnNETe973o0Ok6Dq8jaFYr45bR2Vbnh2JTgysyY=",
+        "lastModified": 1782101684,
+        "narHash": "sha256-llhjsrt57ohO15K+KW4HHAuKDLteF15w99L9KXZL2cE=",
         "owner": "gizmo385",
         "repo": "mux",
-        "rev": "4b8660aabdfb2462fd8c1d1d3d01eef6196ab6dd",
+        "rev": "5a560735fcbd2519ed5ae6c1ffe88c6c1693f490",
         "type": "github"
       },
       "original": {
@@ -66,11 +66,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781497404,
-        "narHash": "sha256-9GAF8sSsnkyCVCWkomXR0T+zdSxyUlfPt6neQidimdg=",
+        "lastModified": 1782134359,
+        "narHash": "sha256-dh0RDcJ17Rubgk3hGTugYmTu6rnUPfRu5vA7MA1Pdo0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1285cd3d6882a9847f2d56ed5541b3350c8a6162",
+        "rev": "979bfee6e1a7996fc395270d54c9b59e88762494",
         "type": "github"
       },
       "original": {
@@ -92,27 +92,48 @@
         ]
       },
       "locked": {
-        "lastModified": 1754860581,
-        "narHash": "sha256-EM0IE63OHxXCOpDHXaTyHIOk2cNvMCGPqLt/IdtVxgk=",
+        "lastModified": 1781955583,
+        "narHash": "sha256-qJjGESnkXp1No6QyI9BjtEHstwtZE8zqLuIBwxE1ugI=",
         "owner": "NuschtOS",
         "repo": "ixx",
-        "rev": "babfe85a876162c4acc9ab6fb4483df88fa1f281",
+        "rev": "86a7f2126da859b62d68378e90a052655fa8da01",
         "type": "github"
       },
       "original": {
         "owner": "NuschtOS",
-        "ref": "v0.1.1",
+        "ref": "v0.2.3",
         "repo": "ixx",
+        "type": "github"
+      }
+    },
+    "nix-index-database": {
+      "inputs": {
+        "nixpkgs": [
+          "nuschtosSearch",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781422160,
+        "narHash": "sha256-W7S8O86bVrw2gaomEwkHStOzmPpnFIHQ6lS4Q2HffJ0=",
+        "owner": "Mic92",
+        "repo": "nix-index-database",
+        "rev": "854d04e2368fb2e9c328a36b3c0a04cd713bfae1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "nix-index-database",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781359544,
-        "narHash": "sha256-iUuzKQcyXvopYDDzFpMK5eQKP3WIJExYny2kJtbgUcE=",
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9f11f828c213641c2369a9f1fa31fe31557e3156",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
         "type": "github"
       },
       "original": {
@@ -148,11 +169,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1781496494,
-        "narHash": "sha256-SfOg25O4vI7jVl4hwxiLAgsa0oiu2K1SPoDtRT3ECNc=",
+        "lastModified": 1782062554,
+        "narHash": "sha256-v2J6/S33H2ms6jz3qr6in0UUlGFqUW46+iB3hMJDuD4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "586286af54a314a24566811ce44eb9f380696e6e",
+        "rev": "b3e7b2d2e568f29becae04217242ed18a90febc4",
         "type": "github"
       },
       "original": {
@@ -167,16 +188,17 @@
           "flake-utils"
         ],
         "ixx": "ixx",
+        "nix-index-database": "nix-index-database",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1781353560,
-        "narHash": "sha256-mJTJ7ASB7PwDVCWpZrKqV1ARlQBb9x3pCVe0mXO6kZM=",
+        "lastModified": 1782044367,
+        "narHash": "sha256-v8GLF/joPIVFJAACjWzCXZwWFdnNDPi0m89LiroN7vU=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "73087ede59ba2749a774b47a00193b906182f234",
+        "rev": "1b4bc60840fbe3d5c9faa866031db49266fe3367",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updates the pinned input versions:
```
unpacking 'github:gizmo385/mux/5a560735fcbd2519ed5ae6c1ffe88c6c1693f490' into the Git cache...
unpacking 'github:nix-community/home-manager/979bfee6e1a7996fc395270d54c9b59e88762494' into the Git cache...
unpacking 'github:nixos/nixpkgs/3e41b24abd260e8f71dbe2f5737d24122f972158' into the Git cache...
unpacking 'github:nix-community/nixvim/b3e7b2d2e568f29becae04217242ed18a90febc4' into the Git cache...
unpacking 'github:NuschtOS/search/1b4bc60840fbe3d5c9faa866031db49266fe3367' into the Git cache...
unpacking 'github:numtide/treefmt-nix/db947814a175b7ca6ded66e21383d938df01c227' into the Git cache...
warning: updating lock file "/home/runner/work/dotfiles/dotfiles/flake.lock":
• Updated input 'agent-mux':
    'github:gizmo385/mux/4b8660a' (2026-05-29)
  → 'github:gizmo385/mux/5a56073' (2026-06-22)
• Updated input 'home-manager':
    'github:nix-community/home-manager/1285cd3' (2026-06-15)
  → 'github:nix-community/home-manager/979bfee' (2026-06-22)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/9f11f82' (2026-06-13)
  → 'github:nixos/nixpkgs/3e41b24' (2026-06-16)
• Updated input 'nixvim':
    'github:nix-community/nixvim/586286a' (2026-06-15)
  → 'github:nix-community/nixvim/b3e7b2d' (2026-06-21)
• Updated input 'nuschtosSearch':
    'github:NuschtOS/search/73087ed' (2026-06-13)
  → 'github:NuschtOS/search/1b4bc60' (2026-06-21)
• Updated input 'nuschtosSearch/ixx':
    'github:NuschtOS/ixx/babfe85' (2025-08-10)
  → 'github:NuschtOS/ixx/86a7f21' (2026-06-20)
• Added input 'nuschtosSearch/nix-index-database':
    'github:Mic92/nix-index-database/854d04e' (2026-06-14)
• Added input 'nuschtosSearch/nix-index-database/nixpkgs':
    follows 'nuschtosSearch/nixpkgs'
```

Package version diff (against `homeConfigurations.docker`):
```
agent-mux: 0.1.2 → 0.1.3
claude-code: 2.1.175 → 2.1.177, 892.0 KiB
home-configuration-reference: 17.8 KiB
ruff: 0.15.16 → 0.15.17, 513.5 KiB
source: 134.1 KiB
```

This PR should automatically merge when builds have been validated.