### PR TITLE
Automatic dotfile version updates (2026-06-29)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782101684,
-        "narHash": "sha256-llhjsrt57ohO15K+KW4HHAuKDLteF15w99L9KXZL2cE=",
+        "lastModified": 1782460400,
+        "narHash": "sha256-DcX3w9MAGhP5YNnzK8RLYJk5va20uzBbHy4KblBvNYc=",
         "owner": "gizmo385",
         "repo": "mux",
-        "rev": "5a560735fcbd2519ed5ae6c1ffe88c6c1693f490",
+        "rev": "2fb1301a7e0948d5c2fc646d6b6135e05566c9c6",
         "type": "github"
       },
       "original": {
@@ -66,11 +66,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782134359,
-        "narHash": "sha256-dh0RDcJ17Rubgk3hGTugYmTu6rnUPfRu5vA7MA1Pdo0=",
+        "lastModified": 1782702263,
+        "narHash": "sha256-8/MG4Su7PhnynrmsVO61IeAfrK7GuUEu+E+gwbhy1QQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "979bfee6e1a7996fc395270d54c9b59e88762494",
+        "rev": "789a35fbdeb3c46b260096daa0b321c11be527ea",
         "type": "github"
       },
       "original": {
@@ -129,11 +129,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781607440,
-        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
+        "lastModified": 1782636521,
+        "narHash": "sha256-OG8laCOGtkxlB1JH3XqOnXxnkGJme4mQdXo5hkhCQIY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
+        "rev": "e1c1b84752fb0897897380a3cae9dc7fcab91ca3",
         "type": "github"
       },
       "original": {
@@ -169,11 +169,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1782062554,
-        "narHash": "sha256-v2J6/S33H2ms6jz3qr6in0UUlGFqUW46+iB3hMJDuD4=",
+        "lastModified": 1782706849,
+        "narHash": "sha256-b2ODGxKD3hgrwuesLtDomp2DKF3UiOn3+EBTDXpcqGo=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "b3e7b2d2e568f29becae04217242ed18a90febc4",
+        "rev": "c6a99bb41fb0f37e03ca38b1d81b006e98e3bf1a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updates the pinned input versions:
```
unpacking 'github:gizmo385/mux/2fb1301a7e0948d5c2fc646d6b6135e05566c9c6' into the Git cache...
unpacking 'github:nix-community/home-manager/789a35fbdeb3c46b260096daa0b321c11be527ea' into the Git cache...
unpacking 'github:nixos/nixpkgs/e1c1b84752fb0897897380a3cae9dc7fcab91ca3' into the Git cache...
unpacking 'github:nix-community/nixvim/c6a99bb41fb0f37e03ca38b1d81b006e98e3bf1a' into the Git cache...
unpacking 'github:NuschtOS/search/1b4bc60840fbe3d5c9faa866031db49266fe3367' into the Git cache...
unpacking 'github:numtide/treefmt-nix/db947814a175b7ca6ded66e21383d938df01c227' into the Git cache...
warning: updating lock file "/home/runner/work/dotfiles/dotfiles/flake.lock":
• Updated input 'agent-mux':
    'github:gizmo385/mux/5a56073' (2026-06-22)
  → 'github:gizmo385/mux/2fb1301' (2026-06-26)
• Updated input 'home-manager':
    'github:nix-community/home-manager/979bfee' (2026-06-22)
  → 'github:nix-community/home-manager/789a35f' (2026-06-29)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/3e41b24' (2026-06-16)
  → 'github:nixos/nixpkgs/e1c1b84' (2026-06-28)
• Updated input 'nixvim':
    'github:nix-community/nixvim/b3e7b2d' (2026-06-21)
  → 'github:nix-community/nixvim/c6a99bb' (2026-06-29)
```

Package version diff (against `homeConfigurations.docker`):
```
agent-mux: 0.1.3 → 0.1.4, 105.4 KiB
asciinema: 3.2.0 → 3.2.1, 39.1 KiB
audit: 4.1.2-unstable-2025-09-06 → 4.1.4
claude-agent-acp: 0.42.0 → 0.52.0, -4.3 MiB
claude-code: 2.1.177 → 2.1.193, -9.5 MiB
expat: 2.8.0 → 2.8.1
gh: 2.94.0 → 2.95.0, 453.3 KiB
glibc: 2.42-61 → 2.42-67
glibc-locales: 2.42-61 → 2.42-67
home-configuration-reference: 11.4 KiB
icu4c: 78.3 added, 39.6 MiB
krb5: 1.22.1 → 1.22.2
libgcrypt: 1.11.2 → 1.12.2, 67.3 KiB
libpng-apng: 1.6.56 → 1.6.58
libxml2: 2.15.2 → 2.15.3
nodejs: 24.15.0 → 24.16.0, 46.9 KiB
nodejs-slim: 24.15.0 → 24.16.0, 1.3 MiB
perl: 16.3 KiB
perl5.42.0-HTTP-Daemon: 6.16 → 6.17
publicsuffix-list: 0-unstable-2026-03-26 → 0-unstable-2026-05-13
pyrefly: 1.0.0 → 1.1.1, -245.9 KiB
python3.13-xmltodict: 1.0.2 → 1.0.4
ruff: 0.15.17 → 0.15.20, 556.5 KiB
sd-switch: 0.6.3 → 0.6.4, 49.9 KiB
simdjson: 4.6.0 → 4.6.4, 24.1 KiB
source: 56.8 KiB
systemd: 260.1 → 260.2, 288.6 KiB
systemd-minimal: 260.1 → 260.2, 66.7 KiB
systemd-minimal-libs: 260.1 → 260.2, 30.3 KiB
unbound: 1.25.0 → 1.25.1
uv: 0.11.19 → 0.11.22, 1.0 MiB
vimplugin-nvim-tree.lua: 1.17.0-unstable-2026-06-08 → 1.17.0-unstable-2026-06-15
```

This PR should automatically merge when builds have been validated.