### PR TITLE
Automatic dotfile version updates (2026-07-06)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782460400,
-        "narHash": "sha256-DcX3w9MAGhP5YNnzK8RLYJk5va20uzBbHy4KblBvNYc=",
+        "lastModified": 1783139686,
+        "narHash": "sha256-4JdSkdE01Z6hfPamGgfhsmgIk/s34K5kbRDRJ53oH9w=",
         "owner": "gizmo385",
         "repo": "mux",
-        "rev": "2fb1301a7e0948d5c2fc646d6b6135e05566c9c6",
+        "rev": "10fcd1723e948e3f0a2ef686c69df56466e8e4c6",
         "type": "github"
       },
       "original": {
@@ -28,11 +28,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -66,11 +66,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782702263,
-        "narHash": "sha256-8/MG4Su7PhnynrmsVO61IeAfrK7GuUEu+E+gwbhy1QQ=",
+        "lastModified": 1783222121,
+        "narHash": "sha256-E/ElL373TO8lQ2aMvYyzN+k4xkVaUGoRqoa8AtM71tI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "789a35fbdeb3c46b260096daa0b321c11be527ea",
+        "rev": "a1645f40777620c4bd2b6d854b290c2fc354a266",
         "type": "github"
       },
       "original": {
@@ -114,11 +114,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781422160,
-        "narHash": "sha256-W7S8O86bVrw2gaomEwkHStOzmPpnFIHQ6lS4Q2HffJ0=",
+        "lastModified": 1782636943,
+        "narHash": "sha256-ripjZa7BBLwL1uS5VJF3s/VpZpWt5ZIQEvkJ/FJNpQw=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "854d04e2368fb2e9c328a36b3c0a04cd713bfae1",
+        "rev": "058b1f9381fa79fcda49982370a750ff92dbba43",
         "type": "github"
       },
       "original": {
@@ -129,11 +129,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782636521,
-        "narHash": "sha256-OG8laCOGtkxlB1JH3XqOnXxnkGJme4mQdXo5hkhCQIY=",
+        "lastModified": 1783279667,
+        "narHash": "sha256-/NAkDSsve+GNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e1c1b84752fb0897897380a3cae9dc7fcab91ca3",
+        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
         "type": "github"
       },
       "original": {
@@ -145,11 +145,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1777168982,
-        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
         "type": "github"
       },
       "original": {
@@ -169,11 +169,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1782706849,
-        "narHash": "sha256-b2ODGxKD3hgrwuesLtDomp2DKF3UiOn3+EBTDXpcqGo=",
+        "lastModified": 1783263374,
+        "narHash": "sha256-JM0KZ9qqavwQ0JMNfUUUk6FpXCLwWD5byad9j6hAWFU=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "c6a99bb41fb0f37e03ca38b1d81b006e98e3bf1a",
+        "rev": "8a95c224e3a1b130ec5c18e612b80995e7b418ac",
         "type": "github"
       },
       "original": {
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782044367,
-        "narHash": "sha256-v8GLF/joPIVFJAACjWzCXZwWFdnNDPi0m89LiroN7vU=",
+        "lastModified": 1783122967,
+        "narHash": "sha256-/6Dgbk7iCzU9UCK1lV2cQjlHkh0L0/E9QmTyktK0ZnM=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "1b4bc60840fbe3d5c9faa866031db49266fe3367",
+        "rev": "36d55b5d41b1f0abd71ecdcee91553480689c376",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updates the pinned input versions:
```
unpacking 'github:gizmo385/mux/10fcd1723e948e3f0a2ef686c69df56466e8e4c6' into the Git cache...
unpacking 'github:hercules-ci/flake-parts/17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e' into the Git cache...
unpacking 'github:nix-community/home-manager/a1645f40777620c4bd2b6d854b290c2fc354a266' into the Git cache...
unpacking 'github:nixos/nixpkgs/f205b5574fd0cb7da5b702a2da51507b7f4fdd1b' into the Git cache...
unpacking 'github:nix-community/nixvim/8a95c224e3a1b130ec5c18e612b80995e7b418ac' into the Git cache...
unpacking 'github:NuschtOS/search/36d55b5d41b1f0abd71ecdcee91553480689c376' into the Git cache...
unpacking 'github:numtide/treefmt-nix/db947814a175b7ca6ded66e21383d938df01c227' into the Git cache...
warning: updating lock file "/home/runner/work/dotfiles/dotfiles/flake.lock":
• Updated input 'agent-mux':
    'github:gizmo385/mux/2fb1301' (2026-06-26)
  → 'github:gizmo385/mux/10fcd17' (2026-07-04)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/f7c1a2d' (2026-05-13)
  → 'github:hercules-ci/flake-parts/17c9d6c' (2026-07-01)
• Updated input 'flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/f590132' (2026-04-26)
  → 'github:nix-community/nixpkgs.lib/db3f255' (2026-06-28)
• Updated input 'home-manager':
    'github:nix-community/home-manager/789a35f' (2026-06-29)
  → 'github:nix-community/home-manager/a1645f4' (2026-07-05)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/e1c1b84' (2026-06-28)
  → 'github:nixos/nixpkgs/f205b55' (2026-07-05)
• Updated input 'nixvim':
    'github:nix-community/nixvim/c6a99bb' (2026-06-29)
  → 'github:nix-community/nixvim/8a95c22' (2026-07-05)
• Updated input 'nuschtosSearch':
    'github:NuschtOS/search/1b4bc60' (2026-06-21)
  → 'github:NuschtOS/search/36d55b5' (2026-07-03)
• Updated input 'nuschtosSearch/nix-index-database':
    'github:Mic92/nix-index-database/854d04e' (2026-06-14)
  → 'github:Mic92/nix-index-database/058b1f9' (2026-06-28)
```

Package version diff (against `homeConfigurations.docker`):
```
agent-mux: 0.1.4 → 0.1.6, 11.9 KiB
claude-code: 2.1.193 → 2.1.201, 10.2 MiB
gh: 2.95.0 → 2.96.0, 20.5 KiB
home-configuration-reference: 14.2 KiB
pyrefly: 1.1.1 → 1.2.0-dev.1, 265.6 KiB
source: 48.2 KiB
tmux: 3.6a → 3.7b, 101.1 KiB
uv: 0.11.22 → 0.11.25, 3.4 MiB
vimplugin-nvim-tree.lua: 1.17.0-unstable-2026-06-15 → 1.17.0-unstable-2026-06-20
```

This PR should automatically merge when builds have been validated.