### PR TITLE
Automatic dotfile version updates (2026-07-20)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783139686,
-        "narHash": "sha256-4JdSkdE01Z6hfPamGgfhsmgIk/s34K5kbRDRJ53oH9w=",
+        "lastModified": 1784157946,
+        "narHash": "sha256-/b35w5bc2LvxH9xUuJ09RsusaxUDmJd97/pnrlhvqlM=",
         "owner": "gizmo385",
         "repo": "mux",
-        "rev": "10fcd1723e948e3f0a2ef686c69df56466e8e4c6",
+        "rev": "f98f87c01174225f47c36e53208b021ae32109f4",
         "type": "github"
       },
       "original": {
@@ -66,11 +66,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783222121,
-        "narHash": "sha256-E/ElL373TO8lQ2aMvYyzN+k4xkVaUGoRqoa8AtM71tI=",
+        "lastModified": 1784546264,
+        "narHash": "sha256-jxVr5EHMYAOkFvS2k0abIvt6NqyshyWmiHHzV17sT2g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a1645f40777620c4bd2b6d854b290c2fc354a266",
+        "rev": "e3dea8e4792b09a6c0eb5836b0284ad05b1acba0",
         "type": "github"
       },
       "original": {
@@ -129,11 +129,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783279667,
-        "narHash": "sha256-/NAkDSsve+GNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s=",
+        "lastModified": 1784525419,
+        "narHash": "sha256-yocJ4I4Kd4as0UPMFs9P7laPvvA2x/Bj8EW46iW3VVM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
+        "rev": "a16c3fde2ffeab7f6326f50f460aaffde7ae066d",
         "type": "github"
       },
       "original": {
@@ -169,11 +169,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1783263374,
-        "narHash": "sha256-JM0KZ9qqavwQ0JMNfUUUk6FpXCLwWD5byad9j6hAWFU=",
+        "lastModified": 1784057377,
+        "narHash": "sha256-yycNej5//EsRbV10moBoh+/63vXEwZD1ZFEiRm6C9rQ=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "8a95c224e3a1b130ec5c18e612b80995e7b418ac",
+        "rev": "07180a087e4a00720dc0731cbcd8dec796974381",
         "type": "github"
       },
       "original": {
@@ -257,11 +257,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780220602,
-        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "lastModified": 1784369104,
+        "narHash": "sha256-47cxbcZODibHv3rELFQ9vZly0vUNkND/atn/U7HLeb0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "rev": "df3c0640565d04a0261253cdd89fce78ec50168a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updates the pinned input versions:
```
unpacking 'github:gizmo385/mux/f98f87c01174225f47c36e53208b021ae32109f4' into the Git cache...
unpacking 'github:nix-community/home-manager/e3dea8e4792b09a6c0eb5836b0284ad05b1acba0' into the Git cache...
unpacking 'github:nixos/nixpkgs/a16c3fde2ffeab7f6326f50f460aaffde7ae066d' into the Git cache...
unpacking 'github:nix-community/nixvim/07180a087e4a00720dc0731cbcd8dec796974381' into the Git cache...
unpacking 'github:NuschtOS/search/36d55b5d41b1f0abd71ecdcee91553480689c376' into the Git cache...
unpacking 'github:numtide/treefmt-nix/df3c0640565d04a0261253cdd89fce78ec50168a' into the Git cache...
warning: updating lock file "/home/runner/work/dotfiles/dotfiles/flake.lock":
• Updated input 'agent-mux':
    'github:gizmo385/mux/10fcd17' (2026-07-04)
  → 'github:gizmo385/mux/f98f87c' (2026-07-15)
• Updated input 'home-manager':
    'github:nix-community/home-manager/a1645f4' (2026-07-05)
  → 'github:nix-community/home-manager/e3dea8e' (2026-07-20)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/f205b55' (2026-07-05)
  → 'github:nixos/nixpkgs/a16c3fd' (2026-07-20)
• Updated input 'nixvim':
    'github:nix-community/nixvim/8a95c22' (2026-07-05)
  → 'github:nix-community/nixvim/07180a0' (2026-07-14)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/db94781' (2026-05-31)
  → 'github:numtide/treefmt-nix/df3c064' (2026-07-18)
```

Package version diff (against `homeConfigurations.docker`):
```
agent-mux: 0.1.6 → 0.1.7, 324.7 KiB
alsa-lib: 1.2.15.3 → 1.2.16
alsa-ucm-conf: 1.2.15.3 → 1.2.16, 71.7 KiB
asciinema: -40.5 KiB
aws-c-http: 0.10.4 → 0.11.0, 12.9 KiB
aws-c-io: 0.22.0 → 0.27.2
claude-agent-acp: 0.52.0 → 0.58.1, 17.3 MiB
claude-code: 2.1.201 → 2.1.214, 13.3 MiB
curl: 8.20.0 → 8.21.0, 31.2 KiB
delta: -12.0 KiB
elfutils: 0.194 → 0.195, 43.3 KiB
expat: 2.8.1 → 2.8.2
eza: 0.23.4 → 0.23.5, 436.7 KiB
file: 5.47 → 5.48, 136.9 KiB
fzf: 0.73.1 → 0.74.1, 83.0 KiB
giflib: 5.2.2 → 6.1.3, 72.4 KiB
gnused: 4.9 → 4.10, 79.0 KiB
gtest: 1.17.0 added, 1.8 MiB
hdrhistogram_c: 0.11.9 added, 385.1 KiB
hwloc: 2.13.0 → 2.14.0, 8.3 KiB
icu4c: 78.3 removed, -39.6 MiB
jq: 1.8.1 → 1.8.2, 8.2 KiB
lazygit: 0.62.2 → 0.63.1, 205.4 KiB
less: 692 → 704, 10.9 KiB
libapparmor: 4.1.7 → 5.0.0, 9.4 KiB
libarchive: 3.8.7 → 3.8.8
libcap: 2.77 → 2.78
libcbor: 0.13.0 → 0.14.0
libgpg-error: 1.59 → 1.61
libjpeg-turbo: 3.1.4 → 3.1.4.1
libksba: 1.6.7 → 1.8.0, 8.5 KiB
libmicrohttpd: 1.0.2 → 1.0.5, 8.1 KiB
libmpc: 1.4.0 → 1.4.1
libsodium: 1.0.22-unstable-2026-04-09 → 1.0.22-unstable-2026-04-16
libtpms: 0.10.2 → 0.10.2-unstable-2026-05-06, 14.6 KiB
libusb: 1.0.29 → 1.0.30
linux-headers: 6.18.7 → 7.0, 134.6 KiB
linux-pam: 1.7.1 → 1.7.2, 12.9 KiB
llhttp: 9.4.1 → 9.4.2
lvm2: 2.03.39 → 2.03.41, 8.1 KiB
nbytes: 0.1.4 added, 46.4 KiB
neovim: 0.12.3 → 0.12.4
neovim-unwrapped: 0.12.3 → 0.12.4
nghttp3: 1.15.0 → 1.16.0
ngtcp2: 1.22.1 → 1.23.0, 51.7 KiB
nil: -35.0 KiB
nix: 2.34.7 → 2.34.8
nix-cmd: 2.34.7 → 2.34.8
nix-expr: 2.34.7 → 2.34.8
nix-fetchers: 2.34.7 → 2.34.8
nix-flake: 2.34.7 → 2.34.8
nix-main: 2.34.7 → 2.34.8
nix-nswrapper: 2.34.7 → 2.34.8
nix-store: 2.34.7 → 2.34.8
nix-util: 2.34.7 → 2.34.8
nixfmt: 1.3.1 → 1.4.0, 93.9 KiB
nixos: (no version) removed
nixos-option: 26.11 added
nodejs: 24.16.0 → 24.18.0, 29.9 KiB
nodejs-slim: 24.16.0 → 24.18.0, 1.8 MiB
nvim-host-python3: 3.13.13 → 3.14.6
openssl: 3.6.2 → 3.6.3
perl5.42.0-Compress-Raw-Bzip2: 2.218 added, 56.7 KiB
perl5.42.0-Compress-Raw-Zlib: 2.222 added, 130.3 KiB
perl5.42.0-HTML-Parser: 3.81 → 3.85
perl5.42.0-HTTP-Message: 6.45 → 7.02
perl5.42.0-IO-Compress: 2.221 added, 885.9 KiB
perl5.42.0-Net-SSLeay: -20.0 KiB
perl5.42.0-libwww-perl: 6.72 → 6.83
procps: -685.9 KiB
pyrefly: 1.2.0-dev.1 → 1.2.0-dev.2, 154.8 KiB
python3: 3.13.13 → 3.14.6, 8.0 MiB
python3.13-argcomplete: 3.6.3 removed, -343.1 KiB
python3.13-cbor2: 5.8.0 removed, -491.0 KiB
python3.13-colorama: 0.4.6 removed, -266.6 KiB
python3.13-greenlet: 3.3.0 removed, -1.1 MiB
python3.13-markdown-it-py: 4.0.0 removed, -752.3 KiB
python3.13-mdurl: 0.1.2 removed, -62.6 KiB
python3.13-msgpack: 1.1.2 removed, -351.3 KiB
python3.13-pygments: 2.20.0 removed, -11.9 MiB
python3.13-pynvim: 0.6.0 removed, -504.1 KiB
python3.13-python-dateutil: 2.9.0.post0 removed, -1.0 MiB
python3.13-pyyaml: 6.0.3 removed, -1006.8 KiB
python3.13-remarshal: 1.3.0 removed, -245.4 KiB
python3.13-rich: 14.3.3 removed, -3.8 MiB
python3.13-rich-argparse: 1.7.2 removed, -223.2 KiB
python3.13-ruamel-base: 1.0.0 removed, -10.3 KiB
python3.13-ruamel-yaml: 0.19.1 removed, -1.8 MiB
python3.13-ruamel-yaml-clib: 0.2.15 removed, -379.3 KiB
python3.13-shtab: 1.8.0 removed, -139.2 KiB
python3.13-six: 1.17.0 removed, -122.6 KiB
python3.13-termcolor: 3.3.0 removed, -43.8 KiB
python3.13-tomli: 2.4.0 removed, -114.4 KiB
python3.13-tomlkit: 0.14.0 removed, -620.5 KiB
python3.13-u-msgpack-python: 2.8.0 removed, -152.4 KiB
python3.13-xmltodict: 1.0.4 removed, -94.8 KiB
python3.13-yq: 3.4.3 removed, -162.8 KiB
python3.14-argcomplete: 3.6.3 added, 350.6 KiB
python3.14-cbor2: 5.8.0 added, 531.2 KiB
python3.14-colorama: 0.4.6 added, 271.9 KiB
python3.14-greenlet: 3.3.0 added, 1.1 MiB
python3.14-markdown-it-py: 4.0.0 added, 839.5 KiB
python3.14-mdurl: 0.1.2 added, 68.0 KiB
python3.14-msgpack: 1.1.2 added, 353.3 KiB
python3.14-pygments: 2.20.0 added, 12.8 MiB
python3.14-pynvim: 0.6.0 added, 579.3 KiB
python3.14-python-dateutil: 2.9.0.post0 added, 1.0 MiB
python3.14-pyyaml: 6.0.3 added, 1012.9 KiB
python3.14-remarshal: 1.3.0 added, 255.5 KiB
python3.14-rich: 15.0.0 added, 4.6 MiB
python3.14-rich-argparse: 1.7.2 added, 244.3 KiB
python3.14-ruamel-base: 1.0.0 added, 10.5 KiB
python3.14-ruamel-yaml: 0.19.1 added, 2.0 MiB
python3.14-ruamel-yaml-clib: 0.2.15 added, 383.3 KiB
python3.14-shtab: 1.8.0 added, 145.5 KiB
python3.14-six: 1.17.0 added, 124.3 KiB
python3.14-termcolor: 3.3.0 added, 44.8 KiB
python3.14-tomli: 2.4.0 added, 128.0 KiB
python3.14-tomlkit: 0.14.0 added, 717.3 KiB
python3.14-u-msgpack-python: 2.8.0 added, 155.2 KiB
python3.14-xmltodict: 1.0.4 added, 95.9 KiB
python3.14-yq: 3.4.3 added, 164.6 KiB
ripgrep: 15.1.0 → 15.2.0, 180.4 KiB
ruff: 0.15.20 → 0.15.22, 21.1 KiB
s2n-tls: -48.0 KiB
socat: 1.8.1.1 → 1.8.1.3
source: 32.0 KiB
sqlite: 3.51.2 → 3.53.1, 231.3 KiB
systemd: 260.2 → 261, 1.8 MiB
systemd-minimal: 260.2 → 261, 1.6 MiB
systemd-minimal-libs: 260.2 → 261, 213.5 KiB
tldr: 10.6 KiB
tree-sitter: 0.26.8 → 0.26.9, -8.6 KiB
tree-sitter-c-neovim: 0.12.3 → 0.12.4
tree-sitter-lua-neovim: 0.12.3 → 0.12.4
tree-sitter-markdown-neovim: 0.12.3 → 0.12.4
tree-sitter-markdown_inline-neovim: 0.12.3 → 0.12.4
tree-sitter-query-neovim: 0.12.3 → 0.12.4
tree-sitter-vim-neovim: 0.12.3 → 0.12.4
tree-sitter-vimdoc-neovim: 0.12.3 → 0.12.4
util-linux-minimal: 2.42 → 2.42.2, 38.3 KiB
uv: 0.11.25 → 0.11.28, 1.9 MiB
vimplugin-nvim-tree.lua: 1.17.0-unstable-2026-06-20 → 1.18.0
which: 2.23 → 2.25
zsh: 5.9.1 → 5.9.2, 83.3 KiB
```

This PR should automatically merge when builds have been validated.