### PR TITLE
Automatic dotfile version updates (2026-07-27)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -66,11 +66,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784546264,
-        "narHash": "sha256-jxVr5EHMYAOkFvS2k0abIvt6NqyshyWmiHHzV17sT2g=",
+        "lastModified": 1785158503,
+        "narHash": "sha256-vEhDKc9JYVGH5CO4nbfqIZmsWiDKLPFReYK6emsFK5U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e3dea8e4792b09a6c0eb5836b0284ad05b1acba0",
+        "rev": "0c486d2b21bb1e4d0e5a11e374deb51587267387",
         "type": "github"
       },
       "original": {
@@ -129,11 +129,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784525419,
-        "narHash": "sha256-yocJ4I4Kd4as0UPMFs9P7laPvvA2x/Bj8EW46iW3VVM=",
+        "lastModified": 1785141334,
+        "narHash": "sha256-kh35kIx7el4Jk8Ki3BH9/Pn1eZYSYLJ6LMALos0zOy0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a16c3fde2ffeab7f6326f50f460aaffde7ae066d",
+        "rev": "38a4887411571457d700c51c64a6e49ead2ed5ab",
         "type": "github"
       },
       "original": {
@@ -169,11 +169,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1784057377,
-        "narHash": "sha256-yycNej5//EsRbV10moBoh+/63vXEwZD1ZFEiRm6C9rQ=",
+        "lastModified": 1785001306,
+        "narHash": "sha256-xWqmquUtqKXLeDZ1oQUO+rV4sjA9TShIJhLL8M5Bozo=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "07180a087e4a00720dc0731cbcd8dec796974381",
+        "rev": "48409beb41e8e28b64e8160ca82d8a93fb628963",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updates the pinned input versions:
```
unpacking 'github:nix-community/home-manager/0c486d2b21bb1e4d0e5a11e374deb51587267387' into the Git cache...
unpacking 'github:nixos/nixpkgs/38a4887411571457d700c51c64a6e49ead2ed5ab' into the Git cache...
unpacking 'github:nix-community/nixvim/48409beb41e8e28b64e8160ca82d8a93fb628963' into the Git cache...
unpacking 'github:NuschtOS/search/36d55b5d41b1f0abd71ecdcee91553480689c376' into the Git cache...
unpacking 'github:numtide/treefmt-nix/df3c0640565d04a0261253cdd89fce78ec50168a' into the Git cache...
warning: updating lock file "/home/runner/work/dotfiles/dotfiles/flake.lock":
• Updated input 'home-manager':
    'github:nix-community/home-manager/e3dea8e' (2026-07-20)
  → 'github:nix-community/home-manager/0c486d2' (2026-07-27)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/a16c3fd' (2026-07-20)
  → 'github:nixos/nixpkgs/38a4887' (2026-07-27)
• Updated input 'nixvim':
    'github:nix-community/nixvim/07180a0' (2026-07-14)
  → 'github:nix-community/nixvim/48409be' (2026-07-25)
```

Package version diff (against `homeConfigurations.docker`):
```
acl: 2.3.2 → 2.4.0, 9.2 KiB
agent-mux: 274.3 KiB
alsa-lib: 1.2.16 → 1.2.16.1
alsa-ucm-conf: 1.2.16 → 1.2.16.1
asciinema: 216.0 KiB
attr: 2.5.2 → 2.6.0
bash: 5.3p9 → 5.3p15
bash-interactive: 5.3p9 → 5.3p15
bat: 80.8 KiB
btop: 9.0 KiB
c-ares: 1.34.6 → 1.34.8, 13.4 KiB
claude-agent-acp: 0.58.1 → 0.60.0, 8.6 MiB
claude-code: 2.1.214 → 2.1.220, 9.3 MiB
delta: 201.1 KiB
eza: 44.8 KiB
fd: 58.7 KiB
gawk: 5.4.0 → 5.4.1, 38.8 KiB
gcc: 15.2.0 → 15.3.0, 312.6 KiB
gcc-wrapper: 15.2.0 → 15.3.0
git: 2.54.0 → 2.55.0, 1.0 MiB
glibc: -28.1 KiB
hdrhistogram_c: 0.11.9 → 0.11.10, 45.8 KiB
icu4c: 76.1 → 78.3, 1.4 MiB
jemalloc: 149.3 KiB
lerc: 4.1.0 → 4.1.1, -20.9 KiB
libapparmor: 5.0.0 → 5.0.1
libevent: 2.1.12 → 2.1.13
libffi: 3.5.2 → 3.7.0, 21.4 KiB
libseccomp: 2.6.0 → 2.6.1
merve: 1.2.2 added, 106.3 KiB
nil: 2025-06-13 → 2026-07-23, 1.3 MiB
nix-fetchers: 8.4 KiB
nodejs-slim: 12.6 KiB
pcre2: 10.46 → 10.47, 14.2 KiB
publicsuffix-list: 0-unstable-2026-05-13 → 0-unstable-2026-06-24
pyrefly: 822.6 KiB
python3: 16.3 KiB
python3.14-cbor2: 5.8.0 → 6.1.3, 804.6 KiB
python3.14-greenlet: 3.3.0 → 3.5.3, 140.0 KiB
python3.14-markdown-it-py: 4.0.0 removed, -839.5 KiB
python3.14-mdurl: 0.1.2 removed, -68.0 KiB
python3.14-msgpack: 1.1.2 → 1.2.1
python3.14-pygments: 2.20.0 removed, -12.8 MiB
python3.14-python-dateutil: 2.9.0.post0 removed, -1.0 MiB
python3.14-remarshal: 1.3.0 → 2.1.3, 89.0 KiB
python3.14-rich: 15.0.0 removed, -4.6 MiB
python3.14-rich-argparse: 1.7.2 removed, -244.3 KiB
python3.14-six: 1.17.0 removed, -124.3 KiB
python3.14-starlark: 0.5.0 added, 1.3 MiB
python3.14-tomli: 2.4.0 → 2.4.1
python3.14-tomlkit: 0.14.0 → 0.15.0, 94.9 KiB
ripgrep: 354.6 KiB
ruby: 29.3 KiB
ruff: 1.1 MiB
sd-switch: 115.3 KiB
source: 11.8 KiB
sqlite: 3.53.1 → 3.53.3, 25.6 KiB
systemd: -8.5 KiB
tree-sitter: 425.3 KiB
tree-sitter-markdown: 0.0.0+rev=f969cd3 → 0.0.0+rev=c357072
tree-sitter-markdown_inline: 0.0.0+rev=f969cd3 → 0.0.0+rev=c357072
util-linux-minimal: -8.0 KiB
uv: 0.11.28 → 0.11.32, 3.2 MiB
vimplugin-nvim-lspconfig: 2.10.0 → 2.11.0, 18.6 KiB
vimplugin-nvim-treesitter: 0.10.0-unstable-2026-04-03 → 0.10.0-unstable-2026-07-23, -9.8 KiB
wayland: 1.25.0 → 1.26.0
xgcc: 15.2.0 → 15.3.0
```

This PR should automatically merge when builds have been validated.