### PR TITLE
Automatic dotfile version updates (2026-08-04)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1782949081,
-        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "lastModified": 1785627969,
+        "narHash": "sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "rev": "427bf4bd9435fdf21321c8cc628c24efc14c0f7a",
         "type": "github"
       },
       "original": {
@@ -66,11 +66,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785158503,
-        "narHash": "sha256-vEhDKc9JYVGH5CO4nbfqIZmsWiDKLPFReYK6emsFK5U=",
+        "lastModified": 1785531816,
+        "narHash": "sha256-vkMnV0JIyw+g/NmcfoajlGaAO+9a0ezia+FZohQJrik=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0c486d2b21bb1e4d0e5a11e374deb51587267387",
+        "rev": "bf9ce9fec78f95f374e8dd3b503863a3ec128ebe",
         "type": "github"
       },
       "original": {
@@ -129,11 +129,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785141334,
-        "narHash": "sha256-kh35kIx7el4Jk8Ki3BH9/Pn1eZYSYLJ6LMALos0zOy0=",
+        "lastModified": 1785747939,
+        "narHash": "sha256-D740uKsMbgsfK2oaDenJLLPIZfq7W0/g4KN/Fls8eKs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "38a4887411571457d700c51c64a6e49ead2ed5ab",
+        "rev": "104240a772428cc2e20d8fd86c9ddbb886bbaff2",
         "type": "github"
       },
       "original": {
@@ -145,11 +145,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1782614948,
-        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
+        "lastModified": 1785031560,
+        "narHash": "sha256-OmshNvn2vupOFpYinLUu+1Dnpu4n7Q5N3ggGVNHpkUI=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
+        "rev": "0e79af5e3d4dcfcd676ab5ba3f95d2e3352e078c",
         "type": "github"
       },
       "original": {
@@ -169,11 +169,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1785001306,
-        "narHash": "sha256-xWqmquUtqKXLeDZ1oQUO+rV4sjA9TShIJhLL8M5Bozo=",
+        "lastModified": 1785763201,
+        "narHash": "sha256-wA373y/B9orM3HatLu9oS+Ke5lmdZyBl/bdjd2gLMq4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "48409beb41e8e28b64e8160ca82d8a93fb628963",
+        "rev": "c7be49306b23a952c0151cf4bbeacd944ed82f2a",
         "type": "github"
       },
       "original": {
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783122967,
-        "narHash": "sha256-/6Dgbk7iCzU9UCK1lV2cQjlHkh0L0/E9QmTyktK0ZnM=",
+        "lastModified": 1785581738,
+        "narHash": "sha256-uKomHYCRIl/xMMTfxKe3ZTenGfIsQSyZhoEede40pWM=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "36d55b5d41b1f0abd71ecdcee91553480689c376",
+        "rev": "90b23eb8b8ed5703b44e787016e266221496ad7c",
         "type": "github"
       },
       "original": {
@@ -257,11 +257,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784369104,
-        "narHash": "sha256-47cxbcZODibHv3rELFQ9vZly0vUNkND/atn/U7HLeb0=",
+        "lastModified": 1785360170,
+        "narHash": "sha256-XE1lKgQ3eIO3E7zWryqcRsax+mYXod/5RHBn4YaR9YE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "df3c0640565d04a0261253cdd89fce78ec50168a",
+        "rev": "d1187f8bc71fb8aab02395869ec3f5c1920f75c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updates the pinned input versions:
```
unpacking 'github:hercules-ci/flake-parts/427bf4bd9435fdf21321c8cc628c24efc14c0f7a' into the Git cache...
unpacking 'github:nix-community/home-manager/bf9ce9fec78f95f374e8dd3b503863a3ec128ebe' into the Git cache...
unpacking 'github:nixos/nixpkgs/104240a772428cc2e20d8fd86c9ddbb886bbaff2' into the Git cache...
unpacking 'github:nix-community/nixvim/c7be49306b23a952c0151cf4bbeacd944ed82f2a' into the Git cache...
unpacking 'github:NuschtOS/search/90b23eb8b8ed5703b44e787016e266221496ad7c' into the Git cache...
unpacking 'github:numtide/treefmt-nix/d1187f8bc71fb8aab02395869ec3f5c1920f75c0' into the Git cache...
warning: updating lock file "/home/runner/work/dotfiles/dotfiles/flake.lock":
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/17c9d6c' (2026-07-01)
  → 'github:hercules-ci/flake-parts/427bf4b' (2026-08-01)
• Updated input 'flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/db3f255' (2026-06-28)
  → 'github:nix-community/nixpkgs.lib/0e79af5' (2026-07-26)
• Updated input 'home-manager':
    'github:nix-community/home-manager/0c486d2' (2026-07-27)
  → 'github:nix-community/home-manager/bf9ce9f' (2026-07-31)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/38a4887' (2026-07-27)
  → 'github:nixos/nixpkgs/104240a' (2026-08-03)
• Updated input 'nixvim':
    'github:nix-community/nixvim/48409be' (2026-07-25)
  → 'github:nix-community/nixvim/c7be493' (2026-08-03)
• Updated input 'nuschtosSearch':
    'github:NuschtOS/search/36d55b5' (2026-07-03)
  → 'github:NuschtOS/search/90b23eb' (2026-08-01)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/df3c064' (2026-07-18)
  → 'github:numtide/treefmt-nix/d1187f8' (2026-07-29)
```

Package version diff (against `homeConfigurations.docker`):
```
audit: 4.1.4 → 4.2
bat: 9.1 KiB
claude-agent-acp: 0.60.0 → 0.64.0, 11.8 MiB
findutils: 4.10.0 → 4.11.0, 170.2 KiB
fzf: 0.74.1 → 0.74.2, 20.1 KiB
gh: 2.96.0 → 2.97.0, 262.3 KiB
home-configuration-reference: 10.8 KiB
libapparmor: 5.0.1 → 5.0.2
libffi: 3.7.0 → 3.7.1
libmicrohttpd: 1.0.5 → 1.0.6
libsodium: 1.0.22-unstable-2026-04-16 → 1.0.22-unstable-2026-07-08
libtiff: 4.7.1 → 4.7.2, 13.0 KiB
libtool: 2.5.4 → 2.6.2
linux-headers: 7.0 → 7.1, 27.2 KiB
nil: -8.7 KiB
nodejs: 24.18.0 → 24.18.1
nodejs-slim: 24.18.0 → 24.18.1
perl5.42.0-Mozilla-CA: 11.5 KiB
pyrefly: 1.2.0-dev.2 → 1.2.0-dev.3, 677.1 KiB
python3: -19.4 KiB
python3.14-remarshal: 2.1.3 → 2.1.4
ruff: 0.15.22 → 0.16.1, 217.3 KiB
s2n-tls: 1.7.2 → 1.7.6, 19.5 KiB
source: 58.7 KiB
systemd: 261 → 261.1, 46.2 KiB
systemd-minimal: 261 → 261.1
systemd-minimal-libs: 261 → 261.1
tzdata: 2026b → 2026c, -9.4 KiB
unbound: 1.25.1 → 1.25.2
uv: 0.11.32 → 0.12.1, -11.5 MiB
vimplugin-nvim-treesitter: 0.10.0-unstable-2026-07-23 → 0.10.0-unstable-2026-07-26
```

This PR should automatically merge when builds have been validated.